### PR TITLE
Adjust padding on content pages

### DIFF
--- a/src/routes/[nav]/[...content]/+page.svelte
+++ b/src/routes/[nav]/[...content]/+page.svelte
@@ -13,13 +13,13 @@
 	<div class="lg:grid lg:grid-cols-4">
 		<article
 			use:tocCrawler={{ mode: 'generate', key: data.html }}
-			class="lg:subgrid lg:col-span-3 max-w-3xl p-5 md:py-20 w-full m-auto space-y-5"
+			class="lg:subgrid lg:col-span-3 max-w-3xl p-5 md:py-10 w-full m-auto space-y-2 md:space-y-5"
 		>
 			<ol class="breadcrumb">
 				{#each breadcrumbs as crumb, index (crumb)}
 					<li class="crumb">
 						<a
-							class="anchor no-underline crumb-separator hover:text-primary-500 hover:opacity-100 hover:underline dark:hover:text-primary-300 dark:text-surface-100"
+							class="text-sm md:text-lg anchor no-underline crumb-separator hover:text-primary-500 hover:opacity-100 hover:underline dark:hover:text-primary-300 dark:text-surface-100"
 							href={`/${breadcrumbs.slice(0, index + 1).join('/')}`}>{crumb}</a
 						>
 					</li>

--- a/src/routes/[x+2e]well-known/core/+page.server.ts
+++ b/src/routes/[x+2e]well-known/core/+page.server.ts
@@ -1,6 +1,7 @@
-import { redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = () => {
-	redirect(307, 'https://pydis.com/.env');
+export const load: PageServerLoad = (event) => {
+	event.setHeaders({ refresh: '0; url=https://pydis.com/.env' });
+	error(404, 'Not found');
 };


### PR DESCRIPTION
Reducing the padding on content pages to py-10 (2.5rem) to reduce the amount of empty space. 

Balance padding on smaller screens too.

Fixes #3