### PR TITLE
Navbar should not be reordered

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,12 +7,7 @@
 	data.searchIndex.then(searchStore.set);
 
 	import { isMacOs, navStore, headerPathFromName } from '$lib';
-	const headingOrder = $navStore.map((x) => x.header);
-	data.topLevelNavItems
-		.then((x) => x?.sort((a, b) => headingOrder.indexOf(a.header) - headingOrder.indexOf(b.header)))
-		.then((x) => {
-			if (x) navStore.set(x);
-		});
+	data.topLevelNavItems.then((x) => x && navStore.set(x));
 
 	import '../app.postcss';
 	import '@fortawesome/fontawesome-free/css/fontawesome.css';


### PR DESCRIPTION
Removes reordering, but preserves initial pre-CMS headers. The CMS should send the correct nav headers in the desired order.

Fixes #2